### PR TITLE
Resolve commonUrlPrefix of protocol-containing urls in a way so the d…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,10 +63,6 @@ exports.findCommonUrlPrefix = function (urls) {
         return '';
     }
 
-    if (urls.length === 1) {
-        return exports.ensureTrailingSlash(urls[0].split('/').slice(0, -1).join('/'));
-    }
-
     var commonPathSegments = [];
     var length = Infinity;
 
@@ -105,6 +101,10 @@ exports.findCommonUrlPrefix = function (urls) {
     if (commonPathSegments[0] === 'file:' && commonPathSegments.length < 3) {
         // This is probably the root of the file system. Add another slash
         commonPathSegments.push('');
+    }
+
+    if (commonPathSegments[0] && commonPathSegments[0].slice(-1) === ':' && commonPathSegments.length > 3 && commonPathSegments.slice(-1)[0].indexOf('.') !== -1) {
+      commonPathSegments.splice(-1, 1, '');
     }
 
     return commonPathSegments.join('/');

--- a/test/index.js
+++ b/test/index.js
@@ -109,8 +109,32 @@ vows.describe('Utility functions in urlTools').addBatch({
     },
     'findCommonUrlPrefix with a single file url as input': {
         topic: urlTools.findCommonUrlPrefix('file:///home/munter/blog/index.html'),
-        'should return the empty string': function (relativeUrl) {
+        'should find the deepest directory': function (relativeUrl) {
             assert.equal(relativeUrl, 'file:///home/munter/blog/');
+        }
+    },
+    'findCommonUrlPrefix with a single http url with a trailing slash as input': {
+        topic: urlTools.findCommonUrlPrefix('http://mntr.dk/'),
+        'should return the domain': function (relativeUrl) {
+            assert.equal(relativeUrl, 'http://mntr.dk/');
+        }
+    },
+    'findCommonUrlPrefix with a single http url with no trailing slash as input': {
+        topic: urlTools.findCommonUrlPrefix('http://mntr.dk'),
+        'should return the domain': function (relativeUrl) {
+            assert.equal(relativeUrl, 'http://mntr.dk');
+        }
+    },
+    'findCommonUrlPrefix with a single https url with a trailing slash as input': {
+        topic: urlTools.findCommonUrlPrefix('https://mntr.dk/'),
+        'should return the domain': function (relativeUrl) {
+            assert.equal(relativeUrl, 'https://mntr.dk/');
+        }
+    },
+    'findCommonUrlPrefix with a single https url with no trailing slash as input': {
+        topic: urlTools.findCommonUrlPrefix('https://mntr.dk'),
+        'should return the domain': function (relativeUrl) {
+            assert.equal(relativeUrl, 'https://mntr.dk');
         }
     }
 })['export'](module);


### PR DESCRIPTION
…omain gets included in the result

Previous behavior:

```js
urlTools.findCommonUrlPrefix('https://mntr.dk'); // 'http:/'
```

New behavior:

```js
urlTools.findCommonUrlPrefix('https://mntr.dk'); // 'http://mntr.dk'
```